### PR TITLE
Update golangci-lint to fix linting issues

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -32,7 +32,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-go-lint-
             - name: Install golangci-lint
-              run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+              run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
             - name: Run golangci-lint
               run: golangci-lint run
 

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -32,7 +32,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-go-lint-
             - name: Install golangci-lint
-              run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
+              run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.61.0
             - name: Run golangci-lint
               run: golangci-lint run
 


### PR DESCRIPTION
# Update golangci-lint Version in GitHub Actions Workflow

This pull request updates the version of `golangci-lint` used in the GitHub Actions workflow for Go tests from `v1.55.2` to `v1.61.0`. This change is necessary to ensure that we are using the latest features and bug fixes from the linter, which might improve code quality and linting accuracy in our project.

## Changes Made:

- Updated the version of `golangci-lint` in the `.github/workflows/go-tests.yaml` file.

### Detailed Changes:

- **File Changed**:
  - `.github/workflows/go-tests.yaml`
- **Modification**:
  - Changed the golangci-lint installation command from:
    ```yaml
    - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
    ```
    to:
    ```yaml
    - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
    ```

## Why This Change is Necessary:

Updating to the latest version of `golangci-lint` will help us take advantage of any improvements in linting capabilities, new features, and critical bug fixes that could impact code quality and development workflow positively. Keeping dependencies up to date is a good practice to avoid technical debt.

## Closed Issues:

- None

Please review the changes and consider merging this update to keep our linting tools current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `golangci-lint` tool in the linting workflow to improve code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->